### PR TITLE
Changes file name for class comment sniff

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -35,7 +35,7 @@
 	<rule ref="PEAR.Commenting.InlineComment" />
 	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/DoubleSlashCommentsInNewLineSniff.php" />
 	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/ValidCommentLineLengthSniff.php" />
-	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/ClassDocCommentSniff.php" />
+	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/ClassCommentSniff.php" />
 	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/NoAuthorAnnotationInFunctionDocCommentSniff.php" />
 
 	<!-- Control structures -->


### PR DESCRIPTION
Due to the file name change in 
https://github.com/typo3-ci/TYPO3SniffPool/commit/e8b9df0377815f343ad2a41f4c21a39984a41cc6
the file reference must be updated here.